### PR TITLE
fix search url

### DIFF
--- a/sickbeard/show_name_helpers.py
+++ b/sickbeard/show_name_helpers.py
@@ -64,7 +64,7 @@ def filterBadReleases(name, show):
 
     #if language not english, search for mandatory
     if show.lang != "en":
-        mandatory = langCodes[show.lang].split(" OR ")
+        #mandatory = langCodes[show.lang].split(" OR ")
         if langCodes[show.lang] in resultFilters:
             resultFilters.remove(langCodes[show.lang])
         logger.log(u"Language for \""+show.name+"\" is "+show.lang+" so im looking for \""+langCodes[show.lang]+"\" in release names", logger.DEBUG)


### PR DESCRIPTION
Durch Commit: c7425cf9824691034eb9ec1a736fb71555b0a384 funktioniert die Suche mit NZB.TO als Provider nicht mehr, da die aufgerufenen URLs keinen Treffer zurück liefern. Davon betroffen ist die manuelle als auch die Backlog Suche. Der angefügte Fix entfernt die Veroderung und macht eine Suche wieder möglich.
