### PR TITLE
fix No NZB/Torrent providers found

### DIFF
--- a/sickbeard/show_name_helpers.py
+++ b/sickbeard/show_name_helpers.py
@@ -64,7 +64,7 @@ def filterBadReleases(name, show):
 
     #if language not english, search for mandatory
     if show.lang != "en":
-        #mandatory = langCodes[show.lang].split(" OR ")
+        mandatory = langCodes[show.lang].split("|")
         if langCodes[show.lang] in resultFilters:
             resultFilters.remove(langCodes[show.lang])
         logger.log(u"Language for \""+show.name+"\" is "+show.lang+" so im looking for \""+langCodes[show.lang]+"\" in release names", logger.DEBUG)


### PR DESCRIPTION
Leider kam es durch diese Änderung: 21680e301d6f8a000c106c90ddde506c4282a5db zu "No NZB/Torrent providers found" Fehlern. Habe die Stelle jetzt wieder einkommentiert und so geändert, dass sie zu den anderen passt. Siehe hier: https://github.com/cytec/Sick-Beard/pull/52 
Nach einem kurzen Test läuft wieder alles so wie es sein sollte. 
