### PR TITLE
changed searching of local db to ignore (some) special characters

### DIFF
--- a/sickbeard/db.py
+++ b/sickbeard/db.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Author: Nic Wolfe <nic@wolfeden.ca>
 # URL: http://code.google.com/p/sickbeard/
 #
@@ -51,6 +52,14 @@ def dbFilename(filename="sickbeard.db", suffix=None):
         filename = "%s.%s" % (filename, suffix)
     return ek.ek(os.path.join, sickbeard.DATA_DIR, filename)
 
+# functions for sqlite UDFs
+def _udf_dropspecialchars(text):
+    reps = {'á':'a', 'ã':'a', 'â':'a', 'é':'e', 'ê':'e', 'í':'i','ó':'o' ,'õ':'o' ,'ô':'o','ú':'u', 'ç':'c', 'ä':'ae', 'ü':'ue', 'ö':'oe', 'ß':'ss'}
+    text = text.lower()
+    for a, b in reps.iteritems():
+        text = text.replace(a, b)
+    return text
+
 class DBConnection:
     def __init__(self, filename="sickbeard.db", suffix=None, row_type=None):
 
@@ -60,6 +69,7 @@ class DBConnection:
             self.connection.row_factory = self._dict_factory
         else:
             self.connection.row_factory = sqlite3.Row
+        self.connection.create_function('dropspecialchars', 1, _udf_dropspecialchars)
 
     def checkDBVersion(self):
         try:

--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -380,7 +380,7 @@ def searchDBForShow(regShowName):
 
     for showName in showNames:
 
-        sqlResults = myDB.select("SELECT * FROM tv_shows WHERE show_name LIKE ? OR tvr_name LIKE ?", [showName, showName])
+        sqlResults = myDB.select("SELECT * FROM tv_shows WHERE dropspecialchars(show_name) LIKE dropspecialchars(?) OR dropspecialchars(tvr_name) LIKE dropspecialchars(?)", [showName, showName])
 
         if len(sqlResults) == 1:
             return (int(sqlResults[0]["tvdb_id"]), sqlResults[0]["show_name"])


### PR DESCRIPTION
This was especially a problem for german umlauts, when the database contained names with umlauts (like "Wickie und die starken Männer", while the release replaced the umlaut with two characters ("Wickie und die starken Maenner"). SQLite "LIKE" comparison does not treat that as alike (and it also fails to treat different case on other special characters correctly).

I'm not sure this is the best way to handle the problem, and I only added some special characters so far (while others may be advisable, too), but it works.
